### PR TITLE
Feature/add prop ancho to dona

### DIFF
--- a/docs/.vuepress/components/donas/cambiando-base.vue
+++ b/docs/.vuepress/components/donas/cambiando-base.vue
@@ -3,7 +3,9 @@
     <DadsigDonas
         ref="donas_cambio_base"
         :datos="datos"
-        :dona_id="'donas_cambio_base'">
+        :dona_id="'donas_cambio_base'"
+        :ancho_dona="400"
+      >
       <template slot="encabezado">
         <div class="encabezado">
           <h3 class="titulo-visualizacion">Título de gráfica con cambio de datos</h3>

--- a/docs/visualizaciones/donas.md
+++ b/docs/visualizaciones/donas.md
@@ -26,6 +26,8 @@ libertad de customizar el componente al modificarlos.
 * `radio_texto`: (_Number_) Cantidad que se multiplica por el ancho del svg para dar un valor a la funciones
   `innerRadius` y `outerRadius` de d3 y que determinan la posición de los textos de porcentaje afuera de la dona. El 
   valor por defecto esde 0.33.
+* `ancho_dona`: (_Number_) El ancho de la dona se podrá personalizar, por defecto usa el ancho del tamaño del contenedor;
+  cada valor equivale a un pixel `(1 = 1px)`.
 
 ## Ejemplos de uso
 
@@ -43,7 +45,7 @@ controles, nomenclaturas, etc. dentro del componente. El HTML es el siguiente,
         ref="donas-slots-tooltip"
         :dona_id="'dona'"
         :datos="datos"
->
+    >
     <template slot="encabezado">
         <div class="slot-encabezado">
             <h4>Título slots</h4>
@@ -84,9 +86,11 @@ archivos `.json`.
 <template>
     <div id="app">
         <DadsigDonas
-                ref="donas_cambio_base"
-                :datos="datos"
-                :dona_id="'donas_cambio_base'">
+            ref="donas_cambio_base"
+            :datos="datos"
+            :dona_id="'donas_cambio_base'"
+            :ancho_dona="400"
+        >
             <template slot="encabezado">
                 <div class="encabezado">
                     <h3 class="titulo-visualizacion">Título de gráfica con cambio de datos</h3>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dadsig-graficas",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dadsig-graficas",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "licence": "MIT",
   "files": [

--- a/src/components/donas/DadsigDonas.vue
+++ b/src/components/donas/DadsigDonas.vue
@@ -1,22 +1,24 @@
 <template>
   <div v-bind:id=dona_id class="contenedor-dona">
     <slot name="encabezado"></slot>
-    <svg class="svg-dona">
-      <g class="grupo-contenedor-de-dona"></g>
-      <g class="grupo-contenedor-tooltip">
-        <foreignObject>
-          <div class="tooltip-contenido">
-            <div class="contenedor-boton-cerrar">
-              <button class="boton-cerrar-tooltip" @click="cerrarTooltip">
-                &times;
-              </button>
+    <div id="svg-adjuster">
+      <svg class="svg-dona">
+        <g class="grupo-contenedor-de-dona"></g>
+        <g class="grupo-contenedor-tooltip">
+          <foreignObject>
+            <div class="tooltip-contenido">
+              <div class="contenedor-boton-cerrar">
+                <button class="boton-cerrar-tooltip" @click="cerrarTooltip">
+                  &times;
+                </button>
+              </div>
+              <p class="tooltip-variable"></p>
+              <p class="tooltip-cifra"></p>
             </div>
-            <p class="tooltip-variable"></p>
-            <p class="tooltip-cifra"></p>
-          </div>
-        </foreignObject>
-      </g>
-    </svg>
+          </foreignObject>
+        </g>
+      </svg>
+    </div>
     <slot name="pie"></slot>
     <div v-show="logo_conacyt" class="grid-column-4 grid-column-6-esc">
       <a class="boton boton-conacyt" href="https://conacyt.mx/" target="_blank">
@@ -62,6 +64,10 @@ export default {
       type: Number,
       default: .33
     },
+    ancho_dona: {
+      type: Number,
+      default: undefined
+    }
   },
   watch: {
     datos: function(new_val,old_val) {
@@ -144,7 +150,10 @@ export default {
           .outerRadius(this.ancho * this.radio_texto);
     },
     configurandoDimensionesParaSVG: function () {
-      this.ancho = document.getElementById(this.dona_id).clientWidth;
+      this.ancho = 
+        (this.ancho_dona !== undefined && this.ancho_dona <= document.getElementById(this.dona_id).clientWidth)
+          ? this.ancho_dona
+          : document.getElementById(this.dona_id).clientWidth;
       this.alto = this.ancho;
       this.svg.attr("width", this.ancho).attr("height", this.ancho);
       this.grupo_contenedor.attr("transform", `translate(${this.ancho * .5}, ${this.alto * .5})`);
@@ -485,6 +494,14 @@ $radio: 10px;
   }
 }
 // svg
+
+#svg-adjuster {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
 svg.svg-dona ::v-deep foreignObject {
   color: #fff;
   font-size: 12px;


### PR DESCRIPTION
Esta nueva propiedad se propone para poder personalizar nuestro tamaño de la gráfica de dona, ya que su comportamiento actual se basa en el tamaño actual del contenedor y esto en ocasiones puede ser un poco contraproducente.